### PR TITLE
Add exception for _thread.error

### DIFF
--- a/main/LolexTools.py
+++ b/main/LolexTools.py
@@ -511,4 +511,8 @@ except(KeyboardInterrupt) as k:
         print(k)
         # shouldn't be as much of a problem with threads
         time.sleep(10)
+except(_thread.error) as l:
+        print("OOPS! Seems an external thread error occured.")
+        print(l)
+        time.sleep(10)
 os._exit(0)


### PR DESCRIPTION
### Description
<!-- What is this pull request for? Include version updates if necessary. -->
This is to fix thread error for example if you try and start too many threads then this error occurs
### Reason to modify
<!-- 
- Why have you modified this?
- Have you made sure it works? Test everything that could be affected and ensure it works correctly
- How do you know this works? Explain what your changes actually do and why you have done them this way.
-->
This is to fix some thread error uncaught bugs. NOT TESTED YET

### Tests and reviews
<!-- Uncomment based on the situation -->
Simple fix _should_ work
<!-- I have tested the code and it works. -->
NOT TESTED YET
<!-- Please review things below: -->
WIP